### PR TITLE
Create "create emuMMC guide (English).md"

### DIFF
--- a/docs/create emuMMC guide (English).md
+++ b/docs/create emuMMC guide (English).md
@@ -1,0 +1,20 @@
+# Creating emuMMC(virual system) for Atmosphere CFW with SD File method :
+* You MUST ensure there is at least 32GB useable space in your microSD card
+1. Press power button and you should be able to get into hekate menu's UI:
+
+![1562381376676](https://user-images.githubusercontent.com/64573431/109381757-26608300-7917-11eb-89b3-7292d420ad42.png)
+
+2. Tap on the forth bottun "emuMMC" to entered emuMMC configuration page
+
+![1562381437740](https://user-images.githubusercontent.com/64573431/109381785-4b54f600-7917-11eb-9639-799a566bdae5.png)
+
+3. Tap on "emuMMC Tools" on the right hand side, then tap "Create emuMMC" ，it will ready to create the virual system as picture showed below:
+
+![1562381630506](https://user-images.githubusercontent.com/64573431/109381847-aa1a6f80-7917-11eb-8ec6-f56ad9da51bb.png)
+
+4. select SD File method to create your emuEMMC, then it shows up screen like below, wait for the process bar until it reach 100% patiently, then it will notice for success creation, it usually would takes time for 11-14 minutes, hardly depends on your microSD card Read/Write speed.
+
+![1562383179986](https://user-images.githubusercontent.com/64573431/109381862-c1595d00-7917-11eb-90c2-4c3f5199a51e.png)
+
+5. Once it show create success, tap "Close" on the right upper corner twice to quite.
+6. Done 😎


### PR DESCRIPTION
This guide would also help as there is alot of simular guide in English out there, but would be useful by puting here too as there is screenshot which is crazyily helpful  espacially for those ShallowSea english users, so I have translate it into English from original editor carcaschoi's create emuMMC guide (chinese).md. SX OS method have been removed, as it is no long able to use already even the DNS have been take down, so it can be removed for easy reading already.  Espacially boot.dat from ShallowSea until v2.10.0 can still bypass the SX Core and SX Lite CFW checking as checked and confirm, and most new user would use HWFLY anyway. Still need some edit as my English is also crappy and a bit unformal to most native English speaker for a README.MD.